### PR TITLE
Eliminated duplicate Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,5 +41,9 @@ install:
 script:
   - molecule test
 
+branches:
+  only:
+    - master
+
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/


### PR DESCRIPTION
For each pull request two builds were being generated:

1. One for the push
2. One for the pull request

This was slowing down development because of the limited number of concurrent builds permitted.

This change ensures only the pull request build is created for pull requests; push builds will still run on the master branch.