### PR TITLE
Changed tests to use host fixture

### DIFF
--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -7,14 +7,14 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def test_inotify_defaults(File):
-    kb = File('/etc/sysctl.d/10-ansible-inotify.conf')
+def test_inotify_defaults(host):
+    kb = host.file('/etc/sysctl.d/10-ansible-inotify.conf')
 
     assert not kb.exists
 
 
-def test_inotify_file_permisions(File):
-    kb = File('/etc/sysctl.d/20-ansible-inotify.conf')
+def test_inotify_file_permisions(host):
+    kb = host.file('/etc/sysctl.d/20-ansible-inotify.conf')
 
     assert kb.exists
     assert kb.is_file
@@ -28,8 +28,8 @@ def test_inotify_file_permisions(File):
     'fs.inotify.max_user_instances=128',
     'fs.inotify.max_user_watches=524288'
 ])
-def test_inotify_file_contents(File, setting):
-    kb = File('/etc/sysctl.d/20-ansible-inotify.conf')
+def test_inotify_file_contents(host, setting):
+    kb = host.file('/etc/sysctl.d/20-ansible-inotify.conf')
 
     assert kb.exists
     assert kb.is_file


### PR DESCRIPTION
Other fixtures are deprecated and will be removed in 2.0 Testinfra release.