### PR TITLE
Made task names case consistent

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
     state: present
   when: "ansible_pkg_mgr == 'apt'"
 
-- name: Set max_queued_events
+- name: set max_queued_events
   become: yes
   sysctl:
     name: fs.inotify.max_queued_events
@@ -16,7 +16,7 @@
     sysctl_file: '{{ inotify_sysctl_file }}'
   when: "inotify_max_queued_events is defined and inotify_max_queued_events not in (None, '', omit)"
 
-- name: Set max_user_instances
+- name: set max_user_instances
   become: yes
   sysctl:
     name: fs.inotify.max_user_instances
@@ -26,7 +26,7 @@
     sysctl_file: '{{ inotify_sysctl_file }}'
   when: "inotify_max_user_instances is defined and inotify_max_user_instances not in (None, '', omit)"
 
-- name: Set max_user_watches
+- name: set max_user_watches
   become: yes
   sysctl:
     name: fs.inotify.max_user_watches


### PR DESCRIPTION
Other GantSign roles use lowercase.