### PR TITLE
Increased minimum Ansible version to 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,19 +11,19 @@ env:
 matrix:
   include:
     - env:
-        - MOLECULEW_ANSIBLE=2.6.18
+        - MOLECULEW_ANSIBLE=2.7.15
         - MOLECULE_SCENARIO=centos
     - env:
-        - MOLECULEW_ANSIBLE=2.6.18
+        - MOLECULEW_ANSIBLE=2.7.15
         - MOLECULE_SCENARIO=debian-min
     - env:
-        - MOLECULEW_ANSIBLE=2.6.18
+        - MOLECULEW_ANSIBLE=2.7.15
         - MOLECULE_SCENARIO=debian-max
     - env:
-        - MOLECULEW_ANSIBLE=2.6.18
+        - MOLECULEW_ANSIBLE=2.7.15
         - MOLECULE_SCENARIO=default
     - env:
-        - MOLECULEW_ANSIBLE=2.6.18
+        - MOLECULEW_ANSIBLE=2.7.15
         - MOLECULE_SCENARIO=ubuntu-min
     - env:
         - MOLECULEW_ANSIBLE=2.9.1

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ particularly when using IDEs.
 Requirements
 ------------
 
-* Ansible >= 2.6
+* Ansible >= 2.7
 
     * Note: earlier versions of Ansible are likely to work but have not been
       tested.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Role for configuring Inotify.
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.6
+  min_ansible_version: 2.7
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
Ansible no longer supports versions earlier than 2.7.