### PR TITLE
Migrated to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Ansible Role: Inotify
 =====================
 
-[![Build Status](https://travis-ci.org/gantsign/ansible-role-inotify.svg?branch=master)](https://travis-ci.org/gantsign/ansible-role-inotify)
+[![Build Status](https://travis-ci.com/gantsign/ansible-role-inotify.svg?branch=master)](https://travis-ci.com/gantsign/ansible-role-inotify)
 [![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-gantsign.inotify-blue.svg)](https://galaxy.ansible.com/gantsign/inotify)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/gantsign/ansible-role-inotify/master/LICENSE)
 


### PR DESCRIPTION
`travis-ci.org` will be discontinued in December.