### PR TITLE
Increased upper Debian test version to Bullseye

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Requirements
 
             * Jessie (8)
             * Stretch (9)
+            * Buster (10)
+            * Bullseye (11)
 
         * Ubuntu
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,6 +17,8 @@ galaxy_info:
       versions:
         - stretch
         - jessie
+        - buster
+        - bullseye
   galaxy_tags:
     - inotify
     - sysctl

--- a/molecule/debian-max/molecule.yml
+++ b/molecule/debian-max/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible-role-inotify-debian-max
-    image: debian:9
+    image: debian:11
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:


### PR DESCRIPTION
Bullseye is the latest stable version of Debian.